### PR TITLE
Support using Git commits for the Docker build context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/.merlin
 _build
 capnp-secrets
+var

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -6,6 +6,13 @@ struct JobDescr {
   cacheHint @1 :Text;
   # Try to place jobs with the same cache_hint on the same node.
   # This will probably be a hash of the first few lines of the Dockerfile.
+
+  repository @2 :Text;
+  # The URL of a Git repository with the commit(s) to use as the context.
+
+  commits @3 :List(Text);
+  # The commit(s) to use as the context. If the list is empty, there will be no context.
+  # If there are multiple items, they will be merged.
 }
 
 interface Job {

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -2,6 +2,7 @@
 
 struct JobDescr {
   dockerfile @0 :Text;
+
   cacheHint @1 :Text;
   # Try to place jobs with the same cache_hint on the same node.
   # This will probably be a hash of the first few lines of the Dockerfile.
@@ -21,7 +22,7 @@ interface Job {
 }
 
 interface Queue {
-  pop @0 (job :Job) -> JobDescr;
+  pop @0 (job :Job) -> (descr :JobDescr);
 }
 
 interface Registration {

--- a/api/submission.ml
+++ b/api/submission.ml
@@ -8,13 +8,7 @@ let local ~submit =
     method submit_impl params release_param_caps =
       let open X.Submit in
       release_param_caps ();
-      let descr =
-        let r = Params.descr_get params in
-        { Queue.
-          dockerfile = Raw.Reader.JobDescr.dockerfile_get r;
-          cache_hint = Raw.Reader.JobDescr.cache_hint_get r;
-        }
-      in
+      let descr = Params.descr_get params in
       let job = submit descr in
       let response, results = Service.Response.create Results.init_pointer in
       Results.job_set results (Some job);

--- a/build-scheduler.opam
+++ b/build-scheduler.opam
@@ -12,6 +12,7 @@ depends: [
   "logs"
   "fmt"
   "conf-libev"
+  "git-unix"
   "ocaml" {>= "4.08.0"}
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}

--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(dirs :standard \ var)

--- a/dune-project
+++ b/dune-project
@@ -17,6 +17,7 @@
   logs
   fmt
   conf-libev
+  git-unix
   (ocaml (>= 4.08.0))
   (alcotest (and (>= 1.0.0) :with-test))
   (alcotest-lwt (and (>= 1.0.1) :with-test))

--- a/scheduler/build_scheduler.ml
+++ b/scheduler/build_scheduler.ml
@@ -89,7 +89,7 @@ let registration_service t =
 
 let submit t (descr : Api.Queue.job_desc) : Api.Job.t =
   let job, set_job = Capability.promise () in
-  Log.info (fun f -> f "Received new job request:\n%s" (String.trim descr.dockerfile));
+  Log.info (fun f -> f "Received new job request");
   let item = { Item.descr; set_job } in
   Queue.add item t.incoming;
   assign t;

--- a/test/mock_builder.ml
+++ b/test/mock_builder.ml
@@ -1,8 +1,10 @@
 open Lwt.Infix
 open Capnp_rpc_lwt
 
+type outcome = (unit, Build_worker.Process.error) result
+
 type t = {
-  replies : (string, (Unix.process_status Lwt.t * Unix.process_status Lwt.u)) Hashtbl.t;
+  replies : (string, (outcome Lwt.t * outcome Lwt.u)) Hashtbl.t;
   cond : unit Lwt_condition.t;
 }
 
@@ -29,36 +31,18 @@ let rec await t id =
     Lwt_condition.wait t.cond >>= fun () ->
     await t id
 
-let build t ~switch ~stdin ~stdout =
-  Lwt_io.read stdin >>= fun dockerfile ->
+let docker_build t ~switch ~log dockerfile =
   Logs.info (fun f -> f "Mock build got %S" dockerfile);
-  Lwt_io.close stdin >>= fun () ->
-  Lwt_io.write stdout (Fmt.strf "Building %s@." dockerfile) >>= fun () ->
+  Build_worker.Log_data.write log (Fmt.strf "Building %s@." dockerfile);
+  let reply = get t dockerfile in
   Lwt_switch.add_hook_or_exec (Some switch) (fun () ->
-      set t dockerfile (Unix.WSIGNALED (-11));
+      if Lwt.state reply = Lwt.Sleep then
+        set t dockerfile @@ Error `Cancelled;
       Lwt.return_unit
     ) >>= fun () ->
-  get t dockerfile >>= fun reply ->
+  reply >|= fun reply ->
   Hashtbl.remove t.replies dockerfile;
-  Lwt_io.close stdout >|= fun () ->
   reply
-
-let docker_build t () =
-  let status, set_status = Lwt.wait () in
-  let from_stdin, to_stdin = Lwt_io.pipe () in
-  let from_stdout, to_stdout = Lwt_io.pipe () in
-  let switch = Lwt_switch.create () in
-  Lwt.async (fun () -> build t ~switch ~stdin:from_stdin ~stdout:to_stdout >|= Lwt.wakeup set_status);
-  object
-    method status = status
-    method stdin = to_stdin
-    method stdout = from_stdout
-    method terminate =
-      if Lwt.state status = Lwt.Sleep then (
-        Logs.info (fun f -> f "Cancelling job");
-        Lwt.async (fun () -> Lwt_switch.turn_off switch)
-      )
-  end
 
 let run ?(capacity=1) ~switch t registration_service =
   let thread = Build_worker.run ~switch ~capacity ~docker_build:(docker_build t) registration_service in

--- a/test/mock_builder.ml
+++ b/test/mock_builder.ml
@@ -31,7 +31,7 @@ let rec await t id =
     Lwt_condition.wait t.cond >>= fun () ->
     await t id
 
-let docker_build t ~switch ~log dockerfile =
+let docker_build t ~switch ~log ~src:_ dockerfile =
   Logs.info (fun f -> f "Mock build got %S" dockerfile);
   Build_worker.Log_data.write log (Fmt.strf "Building %s@." dockerfile);
   let reply = get t dockerfile in

--- a/test/test.ml
+++ b/test/test.ml
@@ -50,7 +50,7 @@ let simple () =
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder registry;
   let result = submit submission_service "example" in
-  Mock_builder.set builder "example" (Unix.WEXITED 0);
+  Mock_builder.set builder "example" @@ Ok ();
   result >>= fun result ->
   Logs.app (fun f -> f "Result: %S" result);
   Alcotest.(check string) "Check job worked" "Building example\nJob succeeded\n" result;
@@ -65,7 +65,7 @@ let fails () =
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder registry;
   let result = submit submission_service "example2" in
-  Mock_builder.set builder "example2" (Unix.WEXITED 1);
+  Mock_builder.set builder "example2" @@ Error (`Exit_code 1);
   result >>= fun result ->
   Logs.app (fun f -> f "Result: %S" result);
   Alcotest.(check string) "Check job worked" "Building example2\nDocker build exited with status 1\nFAILED\n" result;
@@ -80,7 +80,7 @@ let await_builder () =
   let result = submit submission_service "example" in
   Lwt_switch.with_switch @@ fun switch ->
   Mock_builder.run ~switch builder registry;
-  Mock_builder.set builder "example" (Unix.WEXITED 0);
+  Mock_builder.set builder "example" @@ Ok ();
   result >>= fun result ->
   Logs.app (fun f -> f "Result: %S" result);
   Alcotest.(check string) "Check job worked" "Building example\nJob succeeded\n" result;
@@ -98,9 +98,9 @@ let builder_capacity () =
   let r2 = submit submission_service "example2" in
   let r3 = submit submission_service "example3" in
   Lwt.pause () >>= fun () ->
-  Mock_builder.set builder "example1" (Unix.WEXITED 0);
-  Mock_builder.set builder "example2" (Unix.WEXITED 0);
-  Mock_builder.set builder "example3" (Unix.WEXITED 0);
+  Mock_builder.set builder "example1" @@ Ok ();
+  Mock_builder.set builder "example2" @@ Ok ();
+  Mock_builder.set builder "example3" @@ Ok ();
   r1 >>= fun result ->
   Alcotest.(check string) "Check job worked" "Building example1\nJob succeeded\n" result;
   r2 >>= fun result ->
@@ -119,7 +119,7 @@ let network () =
       Lwt_switch.with_switch @@ fun builder_switch ->
       Mock_builder.run_remote builder ~network_switch ~builder_switch registry;
       let result = submit submission_service "example" in
-      Mock_builder.set builder "example" (Unix.WEXITED 0);
+      Mock_builder.set builder "example" @@ Ok ();
       result >>= fun result ->
       Logs.app (fun f -> f "Result: %S" result);
       Alcotest.(check string) "Check job worked" "Building example\nJob succeeded\n" result;
@@ -138,7 +138,7 @@ let worker_disconnects () =
   Mock_builder.run_remote builder ~builder_switch ~network_switch registry;
   (* Run a job to ensure it's connected. *)
   let result = submit submission_service "example" in
-  Mock_builder.set builder "example" (Unix.WEXITED 0);
+  Mock_builder.set builder "example" @@ Ok ();
   result >>= fun result ->
   Alcotest.(check string) "Check job worked" "Building example\nJob succeeded\n" result;
   (* Drop network *)
@@ -150,7 +150,7 @@ let worker_disconnects () =
   (* Worker reconnects *)
   let network_switch = Lwt_switch.create () in
   Mock_builder.run_remote builder ~builder_switch ~network_switch registry;
-  Mock_builder.set builder "example" (Unix.WEXITED 0);
+  Mock_builder.set builder "example" @@ Ok ();
   result >>= fun result ->
   Alcotest.(check string) "Check job worked" "Building example\nJob succeeded\n" result;
   Lwt.return_unit
@@ -177,7 +177,7 @@ let client_disconnects () =
     (* Check job is cancelled. *)
     Logs.info (fun f -> f "Wait for job to stop");
     job_result >|= function
-    | Unix.WSIGNALED (-11) -> ()
+    | Error `Cancelled -> ()
     | _ -> Alcotest.fail "Job should have been cancelled!"
 
 let test_case name fn =

--- a/test/test.ml
+++ b/test/test.ml
@@ -35,7 +35,7 @@ let read_log job =
   aux 0L
 
 let submit service dockerfile =
-  Capability.with_ref (Api.Submission.submit service ~dockerfile ~cache_hint:"1") @@ fun job ->
+  Capability.with_ref (Api.Submission.submit service ~dockerfile ~cache_hint:"1" ?src:None) @@ fun job ->
   read_log job >>= fun log ->
   Api.Job.status job >|= function
   | Ok () -> log

--- a/worker/build_worker.ml
+++ b/worker/build_worker.ml
@@ -1,130 +1,34 @@
 open Lwt.Infix
 open Capnp_rpc_lwt
 
-let src = Logs.Src.create "worker" ~doc:"build-scheduler worker agent"
-module Log = (val Logs.src_log src : Logs.LOG)
-
-module Log_data = struct
-  let max_chunk_size = 10240L
-
-  type t = {
-    data : Buffer.t;
-    mutable cond : [ `Running of unit Lwt_condition.t
-                   | `Finished ]
-  }
-  
-  let create () = 
-    {
-      data = Buffer.create 10240;
-      cond = `Running (Lwt_condition.create ());
-    }
-
-  let rec stream t ~start =
-    let len = Int64.of_int (Buffer.length t.data) in
-    let start = if start < 0L then max 0L (Int64.add len start) else start in
-    let avail = Int64.sub len start in
-    if avail < 0L then Fmt.failwith "Start value out of range!";
-    if avail = 0L then (
-      match t.cond with
-      | `Running cond ->
-        Lwt_condition.wait cond >>= fun () ->
-        stream t ~start
-      | `Finished ->
-        Lwt.return ("", start)
-    ) else (
-      let chunk = min avail max_chunk_size in
-      let next = Int64.add start chunk in
-      let start = Int64.to_int start in
-      let avail = Int64.to_int avail in
-      Lwt.return (Buffer.sub t.data start avail, next)
-    )
-
-  let write t data =
-    match t.cond with
-    | `Running cond ->
-      Buffer.add_string t.data data;
-      Lwt_condition.broadcast cond ()
-    | `Finished ->
-      Fmt.failwith "Attempt to write to log after close: %S" data
-
-  let copy_from_stream t src =
-    let rec aux () =
-      Lwt_io.read ~count:4096 src >>= function
-      | "" -> Lwt.return_unit
-      | data -> write t data; aux ()
-    in
-    aux ()
-
-  let close t =
-    match t.cond with
-    | `Running cond ->
-      t.cond <- `Finished;
-      Lwt_condition.broadcast cond ()
-    | `Finished ->
-      Fmt.failwith "Log already closed!"
-end
-
-let send_to ch contents =
-  Lwt.try_bind
-    (fun () ->
-       Lwt_io.write ch contents >>= fun () ->
-       Lwt_io.close ch
-    )
-    (fun () -> Lwt.return (Ok ()))
-    (fun ex -> Lwt.return (Error (`Msg (Printexc.to_string ex))))
-
-let pp_signal f x =
-  let open Sys in
-  if x = sigkill then Fmt.string f "kill"
-  else if x = sigterm then Fmt.string f "term"
-  else Fmt.int f x
-
-type child_process = <
-  status : Unix.process_status Lwt.t;
-  stdin : Lwt_io.output Lwt_io.channel;
-  stdout : Lwt_io.input Lwt_io.channel;
-  terminate : unit;
->
+module Log_data = Log_data
+module Process = Process
 
 let build ~switch ~docker_build ~log descr =
   let module R = Api.Raw.Reader.JobDescr in
   let dockerfile = R.dockerfile_get descr in
   let cache_hint = R.cache_hint_get descr in
   Log.info (fun f -> f "Got request to build (%s):\n%s" cache_hint (String.trim dockerfile));
-  let proc : child_process = docker_build () in
-  Lwt_switch.add_hook_or_exec (Some switch) (fun () ->
-      if Lwt.state proc#status = Lwt.Sleep then (
-        Log.info (fun f -> f "Asking docker build to terminate");
-        proc#terminate;
-      );
-      Lwt.return_unit
-    )
-  >>= fun () ->
-  let copy_thread = Log_data.copy_from_stream log proc#stdout in
-  send_to proc#stdin dockerfile >>= fun stdin_result ->
-  copy_thread >>= fun () -> (* Ensure all data has been copied before returning *)
-  proc#status >|= function
-  | _ when not (Lwt_switch.is_on switch) ->
+  docker_build ~switch ~log dockerfile >|= function
+  | Error `Cancelled ->
     Log_data.write log (Fmt.strf "Job cancelled");
     Log.info (fun f -> f "Job cancelled");
     Error (`Msg "Build cancelled")
-  | Unix.WEXITED 0 ->
-    begin match stdin_result with
-      | Ok () ->
-        Log_data.write log "Job succeeded\n";
-        Log.info (fun f -> f "Job succeeded");
-        Ok ()
-      | Error (`Msg msg) -> Fmt.failwith "Failed sending Dockerfile to process: %s" msg
-    end
-  | Unix.WEXITED x ->
-    Log_data.write log (Fmt.strf "Docker build exited with status %d@." x);
+  | Ok () ->
+    Log_data.write log "Job succeeded\n";
+    Log.info (fun f -> f "Job succeeded");
+    Ok ()
+  | Error (`Exit_code n) ->
+    Log_data.write log (Fmt.strf "Docker build exited with status %d\n" n);
     Log.info (fun f -> f "Job failed");
     Error (`Msg "Build failed")
-  | Unix.WSIGNALED x -> Fmt.failwith "Docker build failed with signal %d" x
-  | Unix.WSTOPPED x -> Fmt.failwith "Docker build stopped with signal %a" pp_signal x
+  | Error (`Msg msg) ->
+    Log_data.write log (msg ^ "\n");
+    Log.info (fun f -> f "Job failed: %s" msg);
+    Error (`Msg "Build failed")
 
-let docker_build () =
-  (Lwt_process.open_process ~stderr:(`FD_copy Unix.stdout) ("", [| "docker"; "build"; "-" |]) :> child_process)
+let docker_build ~switch ~log dockerfile =
+  Process.exec ~switch ~log ~stdin:dockerfile ["docker"; "build"]
 
 let run ?switch ?(docker_build=docker_build) ~capacity registration_service =
   let cond = Lwt_condition.create () in

--- a/worker/build_worker.ml
+++ b/worker/build_worker.ml
@@ -86,7 +86,10 @@ type child_process = <
   terminate : unit;
 >
 
-let build ~switch ~docker_build ~log { Api.Queue.dockerfile; cache_hint } =
+let build ~switch ~docker_build ~log descr =
+  let module R = Api.Raw.Reader.JobDescr in
+  let dockerfile = R.dockerfile_get descr in
+  let cache_hint = R.cache_hint_get descr in
   Log.info (fun f -> f "Got request to build (%s):\n%s" cache_hint (String.trim dockerfile));
   let proc : child_process = docker_build () in
   Lwt_switch.add_hook_or_exec (Some switch) (fun () ->

--- a/worker/build_worker.mli
+++ b/worker/build_worker.mli
@@ -1,0 +1,15 @@
+val run :
+  ?switch:Lwt_switch.t ->
+  ?docker_build:(switch:Lwt_switch.t ->
+                 log:Log_data.t ->
+                 src:string ->
+                 string -> (unit, Process.error) Lwt_result.t) ->
+  capacity:int ->
+  Api.Registration.t ->
+  unit Lwt.t
+(** [run ~capacity registry] runs a builder that connects to registry and runs up to [capacity] jobs at once.
+    @param switch Turning this off causes the builder to exit (for unit-tests)
+    @param docker_build Used to override the default build action (for unit-tests) *)
+
+module Process = Process
+module Log_data = Log_data

--- a/worker/context.ml
+++ b/worker/context.ml
@@ -1,0 +1,123 @@
+open Lwt.Infix
+
+module Store = Git_unix.Store
+
+let ( / ) = Filename.concat
+let ( >>!= ) = Lwt_result.bind
+
+let state_dir = Sys.getcwd () / "var"
+let repos_dir = state_dir / "git"
+
+let dir_exists d =
+  match Unix.lstat d with
+  | Unix.{ st_kind = S_DIR; _ } -> true
+  | _ -> false
+  | exception Unix.Unix_error(Unix.ENOENT, _, _) -> false
+
+let ensure_dir path =
+  if not (dir_exists path) then Unix.mkdir path 0o700
+
+let get_tmp_dir () =
+  ensure_dir state_dir;
+  let tmp = state_dir / "tmp" in
+  ensure_dir tmp;
+  tmp
+
+let store_err ~label = Lwt_result.map_err (fun e -> `Msg (Fmt.strf "%s: %a" label Store.pp_error e))
+
+module Repo = struct
+  type t = {
+    url : Uri.t;
+    lock : Lwt_mutex.t;
+  }
+
+  let id t =
+    let base = Filename.basename (Uri.path t.url) in
+    let digest = Store.Hash.digest_string (Uri.to_string t.url) in
+    Fmt.strf "%s-%s" base (Store.Hash.to_hex digest)
+
+  let local_copy t =
+    repos_dir / id t
+
+  let v url =
+    let url = Uri.of_string url in
+    match Uri.scheme url with
+    | Some "git" | Some "http" | Some "https" -> { url; lock = Lwt_mutex.create () }
+    | Some x -> Fmt.failwith "Unsupported scheme %S in URL %a" x Uri.pp url
+    | None -> Fmt.failwith "Missing scheme in URL %a" Uri.pp url
+
+  let has_commits t cs =
+    let local_repo = local_copy t in
+    if dir_exists local_repo then (
+      let local_repo = Fpath.v local_repo in
+      Store.v local_repo |> store_err ~label:"Failed to create repository" >>!= fun store ->
+      let rec aux = function
+        | [] -> Lwt_result.return true
+        | c :: cs ->
+          Store.mem store c >>= function
+          | true -> aux cs
+          | false -> Lwt_result.return false
+      in
+      aux cs
+    ) else Lwt_result.return false      (* Don't let ocaml-git try to init a new repository! *)
+
+  let fetch ~switch ~log t =
+    let local_repo = local_copy t in
+    begin
+      if dir_exists local_repo then Lwt_result.return ()
+      else (
+        Lwt_switch.with_switch @@ fun switch -> (* Don't let the user cancel these two. *)
+        Process.exec ~switch ~log ["git"; "init"; local_repo] >>!= fun () ->
+        Process.exec ~switch ~log ["git"; "-C"; local_repo; "remote"; "add"; "origin"; "--mirror=fetch"; "--"; Uri.to_string t.url]
+      )
+    end >>!= fun () ->
+    Process.exec ~switch ~log ["git"; "-C"; local_repo; "fetch"; "--update-head-ok"; "origin"]
+end
+
+let repos = Hashtbl.create 1000
+
+let repo url =
+  match Hashtbl.find_opt repos url with
+  | Some x -> x
+  | None ->
+    let repo = Repo.v url in
+    Hashtbl.add repos url repo;
+    repo
+
+let rec lwt_result_list_iter_s f = function
+  | [] -> Lwt_result.return ()
+  | x :: xs ->
+    f x >>!= fun () ->
+    lwt_result_list_iter_s f xs
+
+let build_context ~switch ~log ~tmpdir descr =
+  match Api.Raw.Reader.JobDescr.commits_get_list descr |> List.map Store.Hash.of_hex with
+  | [] ->
+    Lwt_result.return ()
+  | (c :: cs) as commits ->
+    let repository = repo (Api.Raw.Reader.JobDescr.repository_get descr) in
+    Lwt_mutex.with_lock repository.lock (fun () ->
+        begin
+          Repo.has_commits repository commits >>!= function
+          | true -> Log_data.info log "All commits already cached"; Lwt_result.return ()
+          | false -> Repo.fetch ~switch ~log repository
+        end >>!= fun () ->
+        let clone = Repo.local_copy repository in
+        Process.exec ~switch ~log ["git"; "-C"; clone; "reset"; "--hard"; Store.Hash.to_hex c] >>!= fun () ->
+        Process.exec ~switch ~log ["git"; "-C"; clone; "clean"; "-fdx"] >>!= fun () ->
+        let merge c = Process.exec ~switch ~log ["git"; "-C"; clone; "merge"; Store.Hash.to_hex c] in
+        cs |> lwt_result_list_iter_s merge >>!= fun () ->
+        Process.exec ~switch ~log ["git"; "-C"; clone; "submodule"; "init"] >>!= fun () ->
+        Process.exec ~switch ~log ["git"; "-C"; clone; "submodule"; "update"] >>!= fun () ->
+        Sys.readdir clone |> Array.iter (function
+            | ".git" -> ()
+            | name -> Unix.rename (clone / name) (tmpdir / name)
+          );
+        Lwt_result.return ()
+      )
+
+let with_build_context ~switch ~log descr fn =
+  let tmp = get_tmp_dir () in
+  Lwt_io.with_temp_dir ~parent:tmp ~prefix:"build-context-" @@ fun tmpdir ->
+  build_context ~switch ~log ~tmpdir descr >>!= fun () ->
+  fn tmpdir

--- a/worker/context.mli
+++ b/worker/context.mli
@@ -1,0 +1,26 @@
+(** Fetch and cache the Git repositories used to create the build contexts.
+    It works like this:
+
+    1. We clone the repository in mirror mode. This means that we also see
+       PRs. We could just pull the hashes we want, but future updates can
+       be more efficient if we track what we have in branches.
+
+    2. We use a non-bare repository because we want submodules cached too
+       (using worktrees, the submodule goes into the worktree subdirectory and
+       is lost when the worktree is deleted).
+
+    3. We reset to the first commit and then merge the others. This makes it
+       easy to e.g. test a PR merged with master. Then we fetch any submodules
+       (we don't attempt to merge submodule changes).
+
+    4. Finally, we move all the checked-out files to our desired temporary
+       directory (on the same FS) and release the repository lock. *)
+
+val with_build_context :
+  switch:Lwt_switch.t ->
+  log:Log_data.t ->
+  Api.Raw.Reader.JobDescr.t ->
+  (string -> ('a, Process.error) Lwt_result.t) ->
+  ('a, Process.error) Lwt_result.t
+(** [with_build_context ~switch ~log descr fn] runs [fn dir], where [dir] is a
+    temporary directory containing the requested build context. *)

--- a/worker/dune
+++ b/worker/dune
@@ -1,3 +1,3 @@
 (library
  (name build_worker)
- (libraries api logs capnp-rpc-lwt lwt.unix))
+ (libraries api logs capnp-rpc-lwt lwt.unix git-unix))

--- a/worker/log.ml
+++ b/worker/log.ml
@@ -1,0 +1,2 @@
+let src = Logs.Src.create "worker" ~doc:"build-scheduler worker agent"
+include (val Logs.src_log src : Logs.LOG)

--- a/worker/log_data.ml
+++ b/worker/log_data.ml
@@ -57,3 +57,6 @@ let close t =
     Lwt_condition.broadcast cond ()
   | `Finished ->
     Fmt.failwith "Log already closed!"
+
+let info t fmt =
+  Fmt.kstrf (write t) (fmt ^^ "@.")

--- a/worker/log_data.ml
+++ b/worker/log_data.ml
@@ -1,0 +1,59 @@
+open Lwt.Infix
+
+let max_chunk_size = 10240L
+
+type t = {
+  data : Buffer.t;
+  mutable cond : [ `Running of unit Lwt_condition.t
+                 | `Finished ]
+}
+
+let create () = 
+  {
+    data = Buffer.create 10240;
+    cond = `Running (Lwt_condition.create ());
+  }
+
+let rec stream t ~start =
+  let len = Int64.of_int (Buffer.length t.data) in
+  let start = if start < 0L then max 0L (Int64.add len start) else start in
+  let avail = Int64.sub len start in
+  if avail < 0L then Fmt.failwith "Start value out of range!";
+  if avail = 0L then (
+    match t.cond with
+    | `Running cond ->
+      Lwt_condition.wait cond >>= fun () ->
+      stream t ~start
+    | `Finished ->
+      Lwt.return ("", start)
+  ) else (
+    let chunk = min avail max_chunk_size in
+    let next = Int64.add start chunk in
+    let start = Int64.to_int start in
+    let avail = Int64.to_int avail in
+    Lwt.return (Buffer.sub t.data start avail, next)
+  )
+
+let write t data =
+  match t.cond with
+  | `Running cond ->
+    Buffer.add_string t.data data;
+    Lwt_condition.broadcast cond ()
+  | `Finished ->
+    Fmt.failwith "Attempt to write to log after close: %S" data
+
+let copy_from_stream t src =
+  let rec aux () =
+    Lwt_io.read ~count:4096 src >>= function
+    | "" -> Lwt.return_unit
+    | data -> write t data; aux ()
+  in
+  aux ()
+
+let close t =
+  match t.cond with
+  | `Running cond ->
+    t.cond <- `Finished;
+    Lwt_condition.broadcast cond ()
+  | `Finished ->
+    Fmt.failwith "Log already closed!"

--- a/worker/process.ml
+++ b/worker/process.ml
@@ -1,0 +1,47 @@
+open Lwt.Infix
+
+type error = [
+  | `Cancelled
+  | `Exit_code of int
+  | `Msg of string
+]
+
+let send_to ch contents =
+  Lwt.try_bind
+    (fun () ->
+       Lwt_io.write ch contents >>= fun () ->
+       Lwt_io.close ch
+    )
+    (fun () -> Lwt.return (Ok ()))
+    (fun ex -> Lwt.return (Error (`Msg (Printexc.to_string ex))))
+
+let pp_signal f x =
+  let open Sys in
+  if x = sigkill then Fmt.string f "kill"
+  else if x = sigterm then Fmt.string f "term"
+  else Fmt.int f x
+
+let exec ~log ~switch ?(stdin="") cmd =
+  let cmd = "", Array.of_list cmd in
+  let proc = Lwt_process.open_process ~stderr:(`FD_copy Unix.stdout) cmd in
+  Lwt_switch.add_hook_or_exec (Some switch) (fun () ->
+      if Lwt.state proc#status = Lwt.Sleep then (
+        Log.info (fun f -> f "Cancelling job...");
+        proc#terminate;
+      );
+      Lwt.return_unit
+    )
+  >>= fun () ->
+  let copy_thread = Log_data.copy_from_stream log proc#stdout in
+  send_to proc#stdin stdin >>= fun stdin_result ->
+  copy_thread >>= fun () -> (* Ensure all data has been copied before returning *)
+  proc#status >|= function
+  | _ when not (Lwt_switch.is_on switch) -> Error `Cancelled
+  | Unix.WEXITED 0 ->
+    begin match stdin_result with
+      | Ok () -> Ok ()
+      | Error (`Msg msg) -> Error (`Msg (Fmt.strf "Failed sending input to sub-process: %s" msg))
+    end
+  | Unix.WEXITED n -> Error (`Exit_code n)
+  | Unix.WSIGNALED x -> Error (`Msg (Fmt.strf "Sub-process failed with signal %d" x))
+  | Unix.WSTOPPED x -> Error (`Msg (Fmt.strf "Sub-process stopped with signal %a" pp_signal x))

--- a/worker/process.mli
+++ b/worker/process.mli
@@ -1,0 +1,7 @@
+type error = [
+  | `Cancelled
+  | `Exit_code of int
+  | `Msg of string
+]
+
+val exec : log:Log_data.t -> switch:Lwt_switch.t -> ?stdin:string -> string list -> (unit, error) Lwt_result.t


### PR DESCRIPTION
You can now give the commit(s) to use as the Docker build context. The build worker will download and merge them, caching the Git commits on disk.

Also, the scheduler now keeps the job description in Cap'n Proto format, which means that the scheduler does not need to be updated when new fields are added.