### PR TITLE
Add Prometheus reporting to scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ plus one for the job submission endpoint (for clients).
 
 [Dockerfile](./Dockerfile) can be used to run the scheduler service in a Docker container.
 
+You can also use `--listen-prometheus=PORT` to expose Prometheus metrics on the given port.
+
 ## Workers
 
 Each worker needs access to the `.cap` file for its pool. This tells it how to connect, and

--- a/bin/dune
+++ b/bin/dune
@@ -1,4 +1,4 @@
 (executables
  (public_names build-scheduler build-client build-worker)
  (names scheduler client worker)
- (libraries api logs.fmt fmt.tty capnp-rpc-unix build_scheduler build_worker))
+ (libraries api logs.fmt fmt.tty capnp-rpc-unix build_scheduler build_worker prometheus-app.unix))

--- a/build-scheduler.opam
+++ b/build-scheduler.opam
@@ -14,6 +14,7 @@ depends: [
   "conf-libev"
   "git-unix"
   "lwt-dllist"
+  "prometheus-app"
   "ocaml" {>= "4.08.0"}
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}

--- a/dune-project
+++ b/dune-project
@@ -19,6 +19,7 @@
   conf-libev
   git-unix
   lwt-dllist
+  prometheus-app
   (ocaml (>= 4.08.0))
   (alcotest (and (>= 1.0.0) :with-test))
   (alcotest-lwt (and (>= 1.0.1) :with-test))

--- a/scheduler/build_scheduler.ml
+++ b/scheduler/build_scheduler.ml
@@ -81,7 +81,7 @@ let submission_service t =
 let create pools =
   let pools =
     List.fold_left
-      (fun acc name -> String.Map.add name (Pool_api.create ()) acc)
+      (fun acc name -> String.Map.add name (Pool_api.create ~name) acc)
       String.Map.empty pools
   in
   { pools }

--- a/scheduler/dune
+++ b/scheduler/dune
@@ -1,3 +1,3 @@
 (library
  (name build_scheduler)
- (libraries api logs capnp-rpc-lwt lwt-dllist))
+ (libraries api logs capnp-rpc-lwt lwt-dllist prometheus))

--- a/scheduler/pool.mli
+++ b/scheduler/pool.mli
@@ -5,7 +5,8 @@ module Make (Item : S.ITEM) : sig
   type worker
   (** A connected worker. *)
 
-  val create : unit -> t
+  val create : name:string -> t
+  (** [create ~name] is a pool that reports metrics tagged with [name]. *)
 
   val register : t -> name:string -> (worker, [> `Name_taken]) result
   (** [register t ~name] returns a queue for worker [name]. *)

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
   (name test)
-  (libraries logs.fmt fmt.tty build_worker build_scheduler alcotest-lwt lwt.unix capnp-rpc-net))
+  (libraries logs.fmt fmt.tty build_worker build_scheduler alcotest-lwt lwt.unix capnp-rpc-net prometheus-app))


### PR DESCRIPTION
Reported metrics are:

- Number of connected workers
- Items in the main queue (i.e. unassigned)
- Number of items assigned to a particular worker
- Number of workers ready to accept a new job