### PR TITLE
Don't force amd64 version of Docker

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -10,7 +10,7 @@ RUN opam config exec -- dune build ./_build/install/default/bin/build-worker
 FROM debian:10
 RUN apt-get update && apt-get install libev4 curl gnupg2 git libsqlite3-dev ca-certificates netbase -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
+RUN echo 'deb https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
 RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
 WORKDIR /var/lib/build-worker
 ENTRYPOINT ["/usr/local/bin/build-worker"]


### PR DESCRIPTION
Build workers need to run on other platforms too.