### PR TITLE
Add urgent flag to job submission API

### DIFF
--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -42,5 +42,5 @@ interface Registration {
 }
 
 interface Submission {
-  submit @0 (pool :Text, descr :JobDescr) -> (job :Job);
+  submit @0 (pool :Text, descr :JobDescr, urgent :Bool) -> (job :Job);
 }

--- a/api/submission.ml
+++ b/api/submission.ml
@@ -10,7 +10,8 @@ let local ~submit =
       release_param_caps ();
       let pool = Params.pool_get params in
       let descr = Params.descr_get params in
-      let job = submit ~pool descr in
+      let urgent = Params.urgent_get params in
+      let job = submit ~pool ~urgent descr in
       let response, results = Service.Response.create Results.init_pointer in
       Results.job_set results (Some job);
       Capability.dec_ref job;
@@ -21,11 +22,12 @@ module X = Raw.Client.Submission
 
 type t = X.t Capability.t
 
-let submit ?src t ~pool ~dockerfile ~cache_hint =
+let submit ?src ?(urgent=false) t ~pool ~dockerfile ~cache_hint =
   let open X.Submit in
   let module JD = Raw.Builder.JobDescr in
   let request, params = Capability.Request.create Params.init_pointer in
   Params.pool_set params pool;
+  Params.urgent_set params urgent;
   let b = Params.descr_get params in
   JD.dockerfile_set b dockerfile;
   JD.cache_hint_set b cache_hint;

--- a/scheduler/pool.mli
+++ b/scheduler/pool.mli
@@ -19,8 +19,9 @@ module Make (Item : S.ITEM) : sig
   val register : t -> name:string -> (worker, [> `Name_taken]) result
   (** [register t ~name] returns a queue for worker [name]. *)
 
-  val submit : t -> Item.t -> unit
-  (** [submit t item] adds [item] to the incoming queue. *)
+  val submit : urgent:bool -> t -> Item.t -> unit
+  (** [submit ~urgent t item] adds [item] to the incoming queue.
+      [urgent] items will be processed before non-urgent ones. *)
 
   val pop : worker -> (Item.t, [> `Finished]) Lwt_result.t
   (** [pop worker] gets the next item for [worker]. *)

--- a/test/test_scheduling.ml
+++ b/test/test_scheduling.ml
@@ -53,9 +53,9 @@ let simple () =
   let w2 = Pool.register pool ~name:"worker-2" |> Result.get_ok in
   let w1a = Pool.pop w1 in
   let w2a = Pool.pop w2 in
-  Pool.submit pool @@ job "job1";
-  Pool.submit pool @@ job "job2";
-  Pool.submit pool @@ job "job3";
+  Pool.submit pool ~urgent:false @@ job "job1";
+  Pool.submit pool ~urgent:false @@ job "job2";
+  Pool.submit pool ~urgent:false @@ job "job3";
   Lwt.pause () >>= fun () ->
   Alcotest.(check pop_result) "Worker 1 / job 1" (Ok "job1") (job_state w1a);
   Alcotest.(check pop_result) "Worker 2 / job 1" (Ok "job2") (job_state w2a);
@@ -70,13 +70,13 @@ let cached_scheduling () =
   let w2 = Pool.register pool ~name:"worker-2" |> Result.get_ok in
   let w1a = Pool.pop w1 in
   let w2a = Pool.pop w2 in
-  Pool.submit pool @@ job "job1" ~cache_hint:"a";
-  Pool.submit pool @@ job "job2" ~cache_hint:"b";
-  Pool.submit pool @@ job "job3" ~cache_hint:"a";
-  Pool.submit pool @@ job "job4" ~cache_hint:"a";
-  Pool.submit pool @@ job "job5" ~cache_hint:"c";
+  Pool.submit pool ~urgent:false @@ job "job1" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job2" ~cache_hint:"b";
+  Pool.submit pool ~urgent:false @@ job "job3" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job4" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job5" ~cache_hint:"c";
   Alcotest.(check string) "Jobs queued" "\
-    queue: (backlog) [job5 job4 job3]\n\
+    queue: (backlog) [job5 job4 job3] : []\n\
     registered:\n\
     \  worker-1 (5): [job1(5)]\n\
     \  worker-2 (5): [job2(5)]\n\
@@ -84,7 +84,7 @@ let cached_scheduling () =
     will_cache: a: [worker-1], b: [worker-2]\n" (Fmt.to_to_string Pool.dump pool);
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Jobs started" "\
-    queue: (backlog) [job5 job4 job3]\n\
+    queue: (backlog) [job5 job4 job3] : []\n\
     registered:\n\
     \  worker-1 (0): []\n\
     \  worker-2 (0): []\n\
@@ -95,7 +95,7 @@ let cached_scheduling () =
   (* Worker 2 asks for another job, but the next two jobs would be better done on worker-1. *)
   let w2b = Pool.pop w2 in
   Alcotest.(check string) "Jobs 3 and 4 assigned to worker-1" "\
-    queue: (backlog) []\n\
+    queue: (backlog) [] : []\n\
     registered:\n\
     \  worker-1 (2): [job4(1) job3(1)]\n\
     \  worker-2 (0): []\n\
@@ -109,7 +109,7 @@ let cached_scheduling () =
   Pool.release w1;
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Worker-1's jobs reassigned" "\
-    queue: (backlog) [job4]\n\
+    queue: (backlog) [job4] : []\n\
     registered:\n\
     \  worker-2 (0): []\n\
     cached: a: [worker-1; worker-2], b: [worker-2], c: [worker-2]\n\
@@ -119,7 +119,7 @@ let cached_scheduling () =
   Alcotest.(check pop_result) "Worker 2 / job 4" (Ok "job4") (job_state w2d);
   Pool.release w2;
   Alcotest.(check string) "Idle" "\
-    queue: (backlog) []\n\
+    queue: (backlog) [] : []\n\
     registered:\n\
     cached: a: [worker-1; worker-2], b: [worker-2], c: [worker-2]\n\
     will_cache: \n" (Fmt.to_to_string Pool.dump pool);
@@ -131,19 +131,19 @@ let unbalanced () =
   let pool = Pool.create ~db ~name:"unbalanced" in
   let w1 = Pool.register pool ~name:"worker-1" |> Result.get_ok in
   let w2 = Pool.register pool ~name:"worker-2" |> Result.get_ok in
-  Pool.submit pool @@ job "job1" ~cache_hint:"a";
-  Pool.submit pool @@ job "job2" ~cache_hint:"a";
-  Pool.submit pool @@ job "job3" ~cache_hint:"a";
-  Pool.submit pool @@ job "job4" ~cache_hint:"a";
-  Pool.submit pool @@ job "job5" ~cache_hint:"a";
-  Pool.submit pool @@ job "job6" ~cache_hint:"a";
-  Pool.submit pool @@ job "job7" ~cache_hint:"a";
-  Pool.submit pool @@ job "job8" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job1" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job2" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job3" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job4" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job5" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job6" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job7" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job8" ~cache_hint:"a";
   let _ = Pool.pop w1 in
   let w2a = Pool.pop w2 in
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Worker-2 got jobs eventually" "\
-    queue: (backlog) []\n\
+    queue: (backlog) [] : []\n\
     registered:\n\
     \  worker-1 (6): [job7(1) job6(1) job5(1) job4(1) job3(1) job2(1)]\n\
     \  worker-2 (0): []\n\
@@ -157,14 +157,14 @@ let unbalanced () =
 let no_workers () =
   with_test_db @@ fun db ->
   let pool = Pool.create ~db ~name:"no_workers" in
-  Pool.submit pool @@ job "job1" ~cache_hint:"a";
-  Pool.submit pool @@ job "job2" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job1" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job2" ~cache_hint:"a";
   let w1 = Pool.register pool ~name:"worker-1" |> Result.get_ok in
   let _ = Pool.pop w1 in
   Pool.release w1;
   Lwt.pause () >>= fun () ->
   Alcotest.(check string) "Worker-1 gone" "\
-    queue: (backlog) [job2]\n\
+    queue: (backlog) [job2] : []\n\
     registered:\n\
     cached: a: [worker-1]\n\
     will_cache: \n" (Fmt.to_to_string Pool.dump pool);
@@ -177,7 +177,7 @@ let persist () =
   let pool = Pool.create ~db ~name:"persist" in
   (* worker-1 handles job1 *)
   let w1 = Pool.register pool ~name:"worker-1" |> Result.get_ok in
-  Pool.submit pool @@ job "job1" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job1" ~cache_hint:"a";
   let _ = Pool.pop w1 in
   Pool.release w1;
   (* Create a new instance of the scheduler with the same db. *)
@@ -187,7 +187,7 @@ let persist () =
   let w2a = Pool.pop w2 in
   let w1 = Pool.register pool ~name:"worker-1" |> Result.get_ok in
   let w1a = Pool.pop w1 in
-  Pool.submit pool @@ job "job2" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job2" ~cache_hint:"a";
   Lwt.pause () >>= fun () ->
   Alcotest.(check pop_result) "Worker 1 gets the job" (Ok "job2") (job_state w1a);
   Alcotest.(check pop_result) "Worker 2 doesn't" (Error "pending") (job_state w2a);
@@ -196,6 +196,33 @@ let persist () =
   Lwt.pause () >>= fun () ->
   Lwt.return_unit
 
+(* Urgent jobs go first. *)
+let urgent () =
+  with_test_db @@ fun db ->
+  let pool = Pool.create ~db ~name:"urgent" in
+  Pool.submit pool ~urgent:false @@ job "job1" ~cache_hint:"a";
+  Pool.submit pool ~urgent:true  @@ job "job2" ~cache_hint:"a";
+  Pool.submit pool ~urgent:true  @@ job "job3" ~cache_hint:"a";
+  Pool.submit pool ~urgent:false @@ job "job4" ~cache_hint:"b";
+  let w1 = Pool.register pool ~name:"worker-1" |> Result.get_ok in
+  let w1a = Pool.pop w1 in
+  Alcotest.(check pop_result) "Worker 1 / job 1" (Ok "job2") (job_state w1a);
+  (* Worker 2 joins and gets job 4, due to the cache hints: *)
+  let w2 = Pool.register pool ~name:"worker-2" |> Result.get_ok in
+  let w2a = Pool.pop w2 in
+  Alcotest.(check pop_result) "Worker 2 / job 1" (Ok "job4") (job_state w2a);
+  (* Worker 1 leaves. Jobs 1 and 3 get pushed back, keeping their ugency level. *)
+  Pool.release w1;
+  Alcotest.(check string) "Worker-1 gone" "\
+    queue: (backlog) [job1] : [job3]\n\
+    registered:\n\
+    \  worker-2 (0): []\n\
+    cached: a: [worker-1], b: [worker-2]\n\
+    will_cache: \n" (Fmt.to_to_string Pool.dump pool);
+  (* Urgent job 5 goes ahead of non-urgent job 1, but behind the existing urgent job 3. *)
+  Pool.submit pool ~urgent:true @@ job "job5" ~cache_hint:"b";
+  flush_queue w2 ~expect:["job3"; "job5"; "job1"]
+
 let test_case name fn =
   Alcotest_lwt.test_case name `Quick @@ fun _ () ->
   fn () >|= fun () ->
@@ -203,12 +230,13 @@ let test_case name fn =
   |> Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output
   |> String.split_on_char '\n'
   |> List.iter (fun line ->
-      if Astring.String.is_prefix ~affix:"scheduler_pool_" line then
-        match Astring.String.cut ~sep:" " line with
+      if Astring.String.is_prefix ~affix:"scheduler_pool_" line then (
+        match Astring.String.cut ~sep:"} " line with
         | None -> Fmt.failwith "Bad metrics line: %S" line
         | Some (key, value) ->
           if float_of_string value <> 0.0 then
             Fmt.failwith "Non-zero metric after test: %s=%s" key value
+      )
     )
 
 let suite = [
@@ -217,4 +245,5 @@ let suite = [
   test_case "unbalanced" unbalanced;
   test_case "no_workers" no_workers;
   test_case "persist" persist;
+  test_case "urgent" urgent;
 ]


### PR DESCRIPTION
This is needed for CI so that newly pushed commits get tested before background updates (e.g. for new Docker base images or opam-repository updates).