### PR TITLE
Add an explicit cancel method on jobs

### DIFF
--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -46,6 +46,10 @@ interface Job {
   # Waits for the job to finish. Resolves to an error if the job fails.
   # The output depends on the job type. For a "docker push", it is the RepoId of
   # the pushed image.
+
+  cancel @2 () -> ();
+  # Request that the job be cancelled.
+  # Note: jobs will be also cancelled if their reference count reaches zero.
 }
 
 interface Queue {

--- a/worker/build_worker.ml
+++ b/worker/build_worker.ml
@@ -157,7 +157,10 @@ let docker_build ~switch ~log ~src dockerfile =
        Process.exec ~switch ~log ~stdin:dockerfile ["docker"; "build"; "--iidfile"; iid_file; "-f"; "-"; src] >>!= fun () ->
        Lwt_result.return (String.trim (read_file iid_file))
     )
-    (fun () -> Lwt_unix.unlink iid_file)
+    (fun () ->
+       if Sys.file_exists iid_file then Lwt_unix.unlink iid_file
+       else Lwt.return_unit
+    )
 
 let metrics () =
   let data = Prometheus.CollectorRegistry.(collect default) in

--- a/worker/build_worker.ml
+++ b/worker/build_worker.ml
@@ -83,7 +83,7 @@ let build ~switch ~log t descr =
   end
   >|= function
   | Error `Cancelled ->
-    Log_data.write log (Fmt.strf "Job cancelled");
+    Log_data.write log "Job cancelled\n";
     Log.info (fun f -> f "Job cancelled");
     Error (`Msg "Build cancelled")
   | Ok output ->


### PR DESCRIPTION
This simplifies ref-counting for clients that want to cancel explicitly and allows them to wait for the cancellation to take effect if they
want.

Also, cope better with the `iid` file being deleted (looks like docker removes it if the job is cancelled).