### PR TITLE
Workers forward prometheus-node-exporter metrics to scheduler

### DIFF
--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -57,8 +57,13 @@ interface Queue {
 }
 
 interface Worker {
-  metrics @0 () -> (version :Text, data :Text);
-  # Return the worker's Prometheus metrics.
+  enum MetricsSource {
+    agent @0;   # Report the agent's own metrics
+    host  @1;   # Get the metrics from the prometheus-node-exporter service
+  }
+
+  metrics @0 (source :MetricsSource) -> (contentType :Text, data :Text);
+  # Get Prometheus metrics.
 }
 
 interface Registration {

--- a/api/worker.ml
+++ b/api/worker.ml
@@ -1,3 +1,4 @@
+open Lwt.Infix
 open Capnp_rpc_lwt
 
 let ( >>!= ) = Lwt_result.bind
@@ -7,22 +8,39 @@ let local ~metrics =
   X.local @@ object
     inherit X.service
 
-    method metrics_impl _params release_param_caps =
+    method metrics_impl params release_param_caps =
       let open X.Metrics in
+      let source = Params.source_get params in
       release_param_caps ();
       let response, results = Service.Response.create Results.init_pointer in
-      let version, data = metrics () in
-      Results.version_set results version;
-      Results.data_set results data;
-      Service.return response
+      let collect source =
+        Service.return_lwt @@ fun () ->
+        metrics source >|= function
+        | Ok (content_type, data) ->
+          Results.content_type_set results content_type;
+          Results.data_set results data;
+          Ok response
+        | Error (`Msg msg) ->
+          Error (`Capnp (Capnp_rpc.Error.exn "%s" msg))
+      in
+      match source with
+      | Agent -> collect `Agent
+      | Host -> collect `Host
+      | Undefined _ -> Service.fail "Unknown metrics source"
   end
 
 module X = Raw.Client.Worker
 
 type t = X.t Capability.t
 
-let metrics t =
+let metrics t ~source =
   let open X.Metrics in
-  let request = Capability.Request.create_no_args () in
+  let request, params = Capability.Request.create Params.init_pointer in
+  let source =
+    match source with
+    | `Agent -> Raw.Builder.Worker.MetricsSource.Agent
+    | `Host -> Raw.Builder.Worker.MetricsSource.Host
+  in
+  Params.source_set params source;
   Capability.call_for_value t method_id request >>!= fun results ->
-  Lwt_result.return (Results.version_get results, Results.data_get results)
+  Lwt_result.return (Results.content_type_get results, Results.data_get results)

--- a/build-scheduler.opam
+++ b/build-scheduler.opam
@@ -16,6 +16,7 @@ depends: [
   "git-unix"
   "lwt-dllist"
   "prometheus-app"
+  "cohttp-lwt-unix"
   "sqlite3"
   "ocaml" {>= "4.08.0"}
   "alcotest" {>= "1.0.0" & with-test}

--- a/dune-project
+++ b/dune-project
@@ -31,6 +31,7 @@
   git-unix
   lwt-dllist
   prometheus-app
+  cohttp-lwt-unix
   sqlite3
   (ocaml (>= 4.08.0))
   (alcotest (and (>= 1.0.0) :with-test))

--- a/worker/dune
+++ b/worker/dune
@@ -1,3 +1,3 @@
 (library
  (name build_worker)
- (libraries build_scheduler_api logs capnp-rpc-lwt lwt.unix git-unix prometheus-app))
+ (libraries build_scheduler_api logs capnp-rpc-lwt lwt.unix git-unix prometheus-app cohttp-lwt-unix))


### PR DESCRIPTION
This allows a prometheus service to collect host metrics from workers without workers needing to accept incoming network connections.