### PR TITLE
Allow specifying docker build arguments

### DIFF
--- a/api/docker.ml
+++ b/api/docker.ml
@@ -38,12 +38,14 @@ module Spec = struct
 
   type t = {
     dockerfile : string;
+    build_args : string list;
     push_to : push option;
   }
 
-  let init b { dockerfile; push_to } =
+  let init b { dockerfile; build_args; push_to } =
     let module DB = Raw.Builder.DockerBuild in
     DB.dockerfile_set b dockerfile;
+    DB.build_args_set_list b build_args |> ignore;
     push_to |> Option.iter (fun { target; user; password } ->
         DB.push_target_set b (Image_id.to_string target);
         DB.push_user_set b user;
@@ -56,6 +58,7 @@ module Spec = struct
     let target = R.push_target_get r in
     let user = R.push_user_get r in
     let password = R.push_password_get r in
+    let build_args = R.build_args_get_list r in
     let push_to =
       match target, user, password with
       | "", "", "" -> None
@@ -67,5 +70,5 @@ module Spec = struct
         | Ok target -> Some { target; user; password }
         | Error (`Msg m) -> failwith m
     in
-    { dockerfile; push_to }
+    { dockerfile; build_args; push_to }
 end

--- a/api/docker.mli
+++ b/api/docker.mli
@@ -20,6 +20,7 @@ module Spec : sig
 
   type t = {
     dockerfile : string;       (** The contents of a Dockerfile to build. *)
+    build_args : string list;  (** "--build-arg" arguments. *)
     push_to : push option;     (** Where to upload the resulting image. *)
   }
 

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -15,6 +15,9 @@ struct DockerBuild {
 
   pushUser     @2 :Text;
   pushPassword @3: Text;
+
+  buildArgs    @4: List(Text);
+  # Options to pass to `docker build` using `--build-arg`.
 }
 
 struct JobDescr {

--- a/api/submission.ml
+++ b/api/submission.ml
@@ -25,8 +25,8 @@ type t = X.t Capability.t
 type action =
   | Docker_build of Docker.Spec.t
 
-let docker_build ?push_to dockerfile =
-  Docker_build { Docker.Spec.dockerfile; push_to }
+let docker_build ?push_to ?(build_args=[]) dockerfile =
+  Docker_build { Docker.Spec.dockerfile; build_args; push_to }
 
 let get_action descr =
   let module JD = Raw.Reader.JobDescr in

--- a/build-scheduler-api.opam
+++ b/build-scheduler-api.opam
@@ -10,7 +10,7 @@ depends: [
   "lwt"
   "capnp-rpc-lwt" {>= "0.7.0"}
   "fmt"
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.10.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/build-scheduler.opam
+++ b/build-scheduler.opam
@@ -18,7 +18,7 @@ depends: [
   "prometheus-app"
   "cohttp-lwt-unix"
   "sqlite3"
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.10.0"}
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
 ]

--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,7 @@
   lwt
   (capnp-rpc-lwt (>= 0.7.0))
   fmt
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.10.0))
 ))
 
 (package
@@ -33,7 +33,7 @@
   prometheus-app
   cohttp-lwt-unix
   sqlite3
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.10.0))
   (alcotest (and (>= 1.0.0) :with-test))
   (alcotest-lwt (and (>= 1.0.1) :with-test))
 ))

--- a/test/mock_builder.ml
+++ b/test/mock_builder.ml
@@ -30,7 +30,7 @@ let rec await t id =
     Lwt_condition.wait t.cond >>= fun () ->
     await t id
 
-let docker_build t ~switch ~log ~src:_ dockerfile =
+let docker_build t ~switch ~log ~src:_ ~build_args:_ dockerfile =
   Logs.info (fun f -> f "Mock build got %S" dockerfile);
   Build_worker.Log_data.write log (Fmt.strf "Building %s@." dockerfile);
   let reply = get t dockerfile in

--- a/worker/build_worker.mli
+++ b/worker/build_worker.mli
@@ -3,6 +3,7 @@ val run :
   ?docker_build:(switch:Lwt_switch.t ->
                  log:Log_data.t ->
                  src:string ->
+                 build_args:string list ->
                  string -> (string, Process.error) Lwt_result.t) ->
   ?allow_push:string list ->
   capacity:int ->


### PR DESCRIPTION
Also, always build with `--pull`. If the user didn't specify the exact hash then we always want to pull to ensure consistent results across the cluster.